### PR TITLE
Add mechanism for updating messages when an alloc/dep chanages.

### DIFF
--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -35,7 +35,7 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		os.Exit(sysexits.Software)
 	}
 
-	n, err := notifier.NewNotifier(cfg.Slack)
+	n, err := notifier.NewNotifier(cfg.Slack, watcher.Deployments)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to build new allocations notifier")
 		os.Exit(sysexits.Software)

--- a/cmd/nomad-toast/deployments/command.go
+++ b/cmd/nomad-toast/deployments/command.go
@@ -35,7 +35,7 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		os.Exit(sysexits.Software)
 	}
 
-	n, err := notifier.NewNotifier(cfg.Slack)
+	n, err := notifier.NewNotifier(cfg.Slack, watcher.Allocations)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to build new deployments notifier")
 		os.Exit(sysexits.Software)

--- a/pkg/notifier/format.go
+++ b/pkg/notifier/format.go
@@ -40,7 +40,7 @@ func (n *Notifier) formatDeploymentMessage(d *api.Deployment) {
 		m.Color = dangerColour
 	}
 
-	n.sendNotification(*m)
+	n.sendNotification(d.ID, *m)
 }
 
 func (n *Notifier) formatAllocationMessage(d *api.AllocationListStub) {
@@ -78,5 +78,5 @@ func (n *Notifier) formatAllocationMessage(d *api.AllocationListStub) {
 		m.Color = dangerColour
 	}
 
-	n.sendNotification(*m)
+	n.sendNotification(d.ID, *m)
 }

--- a/pkg/notifier/slack.go
+++ b/pkg/notifier/slack.go
@@ -5,16 +5,65 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (n *Notifier) sendNotification(a slack.Attachment) {
+func (n *Notifier) sendNotification(nomadID string, msg slack.Attachment) {
+	if val, ok := n.state.notifications[nomadID]; !ok {
+		n.sendNewMsg(nomadID, msg)
+	} else {
+		n.sendUpdateMsg(nomadID, val.timestamp, msg)
+	}
+}
 
+func (n *Notifier) sendNewMsg(nomadID string, msg slack.Attachment) {
 	msgOpts := slack.PostMessageParameters{Attachments: []slack.Attachment{}}
-	msgOpts.Attachments = append(msgOpts.Attachments, a)
+	msgOpts.Attachments = append(msgOpts.Attachments, msg)
 
-	id, _, err := n.slack.PostMessage(n.config.slack.Channel, "", msgOpts)
+	chanID, ts, err := n.slack.PostMessage(n.config.slack.Channel, "", msgOpts)
 	if err != nil {
-		log.Error().Err(err).Str("channel", id).Msg("failed to send Slack notification")
+		log.Error().Err(err).Str("channel", chanID).Msg("failed to send new Slack notification")
 		return
 	}
 
-	log.Info().Str("channel", id).Msg("successfully sent Slack notification")
+	n.newNotifierState(nomadID, ts, msg)
+
+	log.Info().Str("channel", chanID).Msg("successfully sent new Slack notification")
+}
+
+func (n *Notifier) sendUpdateMsg(id, ts string, msg slack.Attachment) {
+	u := slack.MsgOptionUpdate(ts)
+	attachOpts := slack.MsgOptionAttachments(msg)
+	opts := []slack.MsgOption{u, attachOpts}
+
+	chanID, ts, _, err := n.slack.SendMessage(n.config.slack.Channel, opts...)
+	if err != nil {
+		log.Error().Err(err).Str("channel", chanID).Msg("failed to send update Slack notification")
+	}
+
+	n.updateNotifierState(id, ts, msg)
+
+	log.Info().Str("channel", chanID).Msg("successfully sent new Slack notification")
+}
+
+func (n *Notifier) newNotifierState(id, ts string, msg slack.Attachment) {
+	log.Debug().
+		Str("ts", ts).
+		Str("id", id).
+		Msg("adding new entry into notifier state tracking")
+
+	m := []slack.Attachment{msg}
+	n.state.Lock()
+	n.state.notifications[id] = notification{ts, m}
+	n.state.Unlock()
+}
+
+func (n *Notifier) updateNotifierState(id, ts string, msg slack.Attachment) {
+	log.Debug().
+		Str("ts", ts).
+		Str("id", id).
+		Msg("adding update into notifier state tracking")
+
+	n.state.Lock()
+	s := n.state.notifications[id]
+	s.timestamp = ts
+	s.messages = append(s.messages, msg)
+	n.state.Unlock()
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -67,8 +67,8 @@ func (w *Watcher) Run() {
 	}
 }
 
-func (w *Watcher) indexHasChange(o, n uint64) bool {
-	if n < o {
+func (w *Watcher) indexHasChange(new, old uint64) bool {
+	if new < old {
 		return false
 	}
 	return true


### PR DESCRIPTION
Previously a new message would be sent everytime to state of a
deployment or allocation changed. This caused quite a lot of noise
with channels and made it hard to figure out the final outcome.

This change adds the ability to send updates to messages so that
each message will eventually represent the final outcome of that
action. To perform this a small internal state tracking system
has been added as this is needed to update Slack messages. After
this work is needed to prune the state, otherwise it will grow
and grow until the application is restarted.

Closes #1