### PR TITLE
Add region identifier to the deployment notifications.

### DIFF
--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -1,6 +1,7 @@
 package allocations
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -41,13 +42,15 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		os.Exit(sysexits.Software)
 	}
 
-	w, err := watcher.NewWatcher(cfg.Nomad, watcher.Allocations, n.MsgChan)
+	w, region, err := watcher.NewWatcher(cfg.Nomad, watcher.Allocations, n.MsgChan)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to build new allocations watcher")
 		os.Exit(sysexits.Software)
 	}
 
-	go n.Run()
+	fmt.Println(region)
+
+	go n.Run(region)
 	go w.Run()
 
 	sigCh := make(chan os.Signal, 5)

--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -1,7 +1,6 @@
 package allocations
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -47,8 +46,6 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		log.Error().Err(err).Msg("unable to build new allocations watcher")
 		os.Exit(sysexits.Software)
 	}
-
-	fmt.Println(region)
 
 	go n.Run(region)
 	go w.Run()

--- a/cmd/nomad-toast/deployments/command.go
+++ b/cmd/nomad-toast/deployments/command.go
@@ -41,13 +41,13 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		os.Exit(sysexits.Software)
 	}
 
-	w, err := watcher.NewWatcher(cfg.Nomad, watcher.Deployments, n.MsgChan)
+	w, region, err := watcher.NewWatcher(cfg.Nomad, watcher.Deployments, n.MsgChan)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to build new deployments watcher")
 		os.Exit(sysexits.Software)
 	}
 
-	go n.Run()
+	go n.Run(region)
 	go w.Run()
 
 	sigCh := make(chan os.Signal, 5)

--- a/pkg/config/nomad.go
+++ b/pkg/config/nomad.go
@@ -9,11 +9,13 @@ import (
 type NomadConfig struct {
 	AllowStale   bool
 	NomadAddress string
+	NomadRegion  string
 }
 
 const (
 	configKeyNomadAllowStale = "nomad-allow-stale"
 	configKeyNomadAddress    = "nomad-address"
+	configKeyNomadRegion     = "nomad-region"
 )
 
 // GetNomadConfig uses viper to populate a NomadConfig struct with values.
@@ -21,6 +23,7 @@ func GetNomadConfig() NomadConfig {
 	return NomadConfig{
 		AllowStale:   viper.GetBool(configKeyNomadAllowStale),
 		NomadAddress: viper.GetString(configKeyNomadAddress),
+		NomadRegion:  viper.GetString(configKeyNomadRegion),
 	}
 }
 
@@ -47,6 +50,19 @@ func RegisterNomadConfig(cmd *cobra.Command) {
 			longOpt      = "nomad-address"
 			defaultValue = "http://localhost:4646"
 			description  = "The Nomad HTTP(S) API address"
+		)
+
+		flags.String(longOpt, defaultValue, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
+			key          = configKeyNomadRegion
+			longOpt      = "nomad-region"
+			defaultValue = ""
+			description  = "The Nomad region to query."
 		)
 
 		flags.String(longOpt, defaultValue, description)

--- a/pkg/notifier/format.go
+++ b/pkg/notifier/format.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
@@ -29,7 +30,11 @@ func (n *Notifier) formatDeploymentMessage(d *api.Deployment) {
 		})
 	}
 
-	m := &slack.Attachment{Fallback: "", Text: "Nomad Deployment Notification", Fields: f}
+	m := &slack.Attachment{
+		Fallback: "",
+		Text:     fmt.Sprintf("Nomad Deployment Notification: %s", strings.ToUpper(n.nomadRegion)),
+		Fields:   f,
+	}
 	m.Fields = f
 
 	switch d.Status {
@@ -67,7 +72,11 @@ func (n *Notifier) formatAllocationMessage(d *api.AllocationListStub) {
 		})
 	}
 
-	m := &slack.Attachment{Fallback: "", Text: "Nomad Allocations Notification", Fields: f}
+	m := &slack.Attachment{
+		Fallback: "",
+		Text:     fmt.Sprintf("Nomad Allocations Notification: %s", strings.ToUpper(n.nomadRegion)),
+		Fields:   f,
+	}
 	m.Fields = f
 
 	switch d.ClientStatus {

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -17,6 +17,8 @@ type Notifier struct {
 	state  *notifications
 
 	MsgChan chan interface{}
+
+	nomadRegion string
 }
 
 type notifierConfig struct {
@@ -46,8 +48,10 @@ func NewNotifier(cfg *config.SlackConfig, et watcher.EndpointType) (*Notifier, e
 }
 
 // Run triggers the notifier to start listening for messages.
-func (n *Notifier) Run() {
+func (n *Notifier) Run(region string) {
 	log.Info().Msgf("starting %s notifier", n.state.nomadType)
+
+	n.nomadRegion = region
 
 	for {
 		select {


### PR DESCRIPTION
This change adds a Nomad region CLI var for configuring the Nomad
client. In addition, if this is set the Nomad region will be added
to the notifications heading. If not passed, when setting up the
client, the local agent will be interogated to determine the local
region. Adding the region to notifications, is important in envs
which have multiple Nomad region.