### PR TITLE
WIP: (#10) Add filtering of alloc notifies by state

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ nomad-toast supports the following global flags:
 
 Allocations triggers a watcher on the Nomad allocations endpoint and will notify you when allocations go through a state change. This can be helpful when keeping an eye on failed allocations, or just to have a general insight into allocation churn.
 
+The allocations command supports the following flags:
+
+* **--include-states** (comma separated list of strings: "") Comma-separated list of allocation client states that will be whitelisted for notifications. If specified, *only* these states will be included in notifications.
+* **--exclude-states** (comma separated list of strings: "") Comma-separated list of allocation client states that will be excluded from notifications. This takes priority over include-states.
+
+The set of client states is defined by the Nomad API - see the `AllocClientStatus` constants [in the API docs](https://godoc.org/github.com/hashicorp/nomad/api#pkg-constants).
+
 #### Command: `deployments`
 
 Deployments triggers a watcher on the Nomad deployments endpoint. This allows you to get notified of deployment activities on your cluster and allows stakeholders to gain insight.

--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -33,7 +33,9 @@ func RegisterCommand(rootCmd *cobra.Command) error {
 		const (
 			key         = cfgKeyAllocIncludeCStates
 			longOpt     = cfgKeyAllocIncludeCStates
-			description = "Whitelist allocation client states. If specified, *only* these states will be included in notifications."
+			description = "Comma-separated list of allocation client states that will be whitelisted for notifications. \n" +
+				"If specified, *only* these states will be included in notifications. The set of client states is defined by the \n" +
+				"Nomad API - see the AllocClientStatus* constants in the docs: https://godoc.org/github.com/hashicorp/nomad/api#pkg-constants."
 		)
 
 		flags.StringSlice(longOpt, []string{}, description)
@@ -45,7 +47,9 @@ func RegisterCommand(rootCmd *cobra.Command) error {
 		const (
 			key         = cfgKeyAllocExcludeCStates
 			longOpt     = cfgKeyAllocExcludeCStates
-			description = "List of allocation client states that will be excluded from notifications. Takes priority over include-states."
+			description = "Comma-separated list of allocation client states that will be excluded from notifications. \n" +
+				"This takes priority over include-states. The set of client states is defined by the \n" +
+				"Nomad API - see the AllocClientStatus* constants in the docs: https://godoc.org/github.com/hashicorp/nomad/api#pkg-constants."
 		)
 
 		flags.StringSlice(longOpt, []string{}, description)

--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -10,6 +10,12 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/sean-/sysexits"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	cfgKeyAllocIncludeCStates = "include-states"
+	cfgKeyAllocExcludeCStates = "exclude-states"
 )
 
 // RegisterCommand is used to register the deployments nomad-toast command.
@@ -22,6 +28,31 @@ func RegisterCommand(rootCmd *cobra.Command) error {
 		},
 	}
 
+	flags := cmd.Flags()
+	{
+		const (
+			key         = cfgKeyAllocIncludeCStates
+			longOpt     = cfgKeyAllocIncludeCStates
+			description = "Whitelist of allocation client states to notify about."
+		)
+
+		flags.StringSlice(longOpt, []string{}, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, []string{})
+	}
+
+	{
+		const (
+			key         = cfgKeyAllocExcludeCStates
+			longOpt     = cfgKeyAllocExcludeCStates
+			description = "Blacklist of allocation client states to notify about. Takes priority over whitelisting."
+		)
+
+		flags.StringSlice(longOpt, []string{}, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, []string{})
+	}
+
 	rootCmd.AddCommand(cmd)
 
 	return nil
@@ -31,7 +62,7 @@ func runDeployments(_ *cobra.Command, _ []string) {
 
 	cfg, err := getConfig()
 	if err != nil {
-		log.Error().Err(err).Msg("unable to load allocations config")
+		log.Error().Err(err).Msg("unable to load nomad-toast config")
 		os.Exit(sysexits.Software)
 	}
 

--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -33,7 +33,7 @@ func RegisterCommand(rootCmd *cobra.Command) error {
 		const (
 			key         = cfgKeyAllocIncludeCStates
 			longOpt     = cfgKeyAllocIncludeCStates
-			description = "Whitelist of allocation client states to notify about."
+			description = "Whitelist allocation client states. If specified, *only* these states will be included in notifications."
 		)
 
 		flags.StringSlice(longOpt, []string{}, description)
@@ -45,7 +45,7 @@ func RegisterCommand(rootCmd *cobra.Command) error {
 		const (
 			key         = cfgKeyAllocExcludeCStates
 			longOpt     = cfgKeyAllocExcludeCStates
-			description = "Blacklist of allocation client states to notify about. Takes priority over whitelisting."
+			description = "List of allocation client states that will be excluded from notifications. Takes priority over include-states."
 		)
 
 		flags.StringSlice(longOpt, []string{}, description)

--- a/cmd/nomad-toast/allocations/config.go
+++ b/cmd/nomad-toast/allocations/config.go
@@ -2,10 +2,12 @@ package allocations
 
 import (
 	"github.com/jrasell/nomad-toast/pkg/config"
+	"github.com/spf13/viper"
 )
 
 func getConfig() (*config.ToastConfig, error) {
 	nomadConfig := config.GetNomadConfig()
+	nomadConfig.AllocCfg = getAllocConfig()
 	slackConfig := config.GetSlackConfig()
 	uiConfig := config.GetUIConfig()
 
@@ -14,4 +16,11 @@ func getConfig() (*config.ToastConfig, error) {
 		Slack: &slackConfig,
 		UI:    &uiConfig,
 	}, nil
+}
+
+func getAllocConfig() *config.AllocConfig {
+	return &config.AllocConfig{
+		IncludeStates: viper.GetStringSlice(cfgKeyAllocIncludeCStates),
+		ExcludeStates: viper.GetStringSlice(cfgKeyAllocExcludeCStates),
+	}
 }

--- a/pkg/config/nomad.go
+++ b/pkg/config/nomad.go
@@ -5,11 +5,18 @@ import (
 	"github.com/spf13/viper"
 )
 
+// AllocConfig is the nomad-toast config struct holding the config specific to allocations
+type AllocConfig struct {
+	IncludeStates []string
+	ExcludeStates []string
+}
+
 // NomadConfig is the nomad-toast Nomad client config struct.
 type NomadConfig struct {
 	AllowStale   bool
 	NomadAddress string
 	NomadRegion  string
+	AllocCfg     *AllocConfig // allocation specific config
 }
 
 const (

--- a/pkg/watcher/allocations.go
+++ b/pkg/watcher/allocations.go
@@ -1,11 +1,11 @@
 package watcher
 
 import (
+	"strings"
 	"time"
 
-	"github.com/jrasell/nomad-toast/pkg/config"
-
 	"github.com/hashicorp/nomad/api"
+	"github.com/jrasell/nomad-toast/pkg/config"
 	"github.com/rs/zerolog/log"
 )
 
@@ -71,16 +71,16 @@ func (w *Watcher) runAllocationWatcher() {
 
 // isFiltered checks whether a given update about a notification is to be filtered or not
 func isFiltered(alloc *api.AllocationListStub, allocCfg *config.AllocConfig) bool {
-	for _, cs := range allocCfg.ExcludeStates {
-		if alloc.ClientStatus == cs {
+	for i := range allocCfg.ExcludeStates {
+		if strings.ToLower(alloc.ClientStatus) == strings.ToLower(allocCfg.ExcludeStates[i]) {
 			log.Debug().Str("alloc-id", alloc.ID).Str("client-status", alloc.ClientStatus).Msg("allocation client status blacklisted, omitting")
 			return true
 		}
 	}
 
 	if allocCfg.IncludeStates != nil {
-		for _, cs := range allocCfg.IncludeStates {
-			if alloc.ClientStatus == cs {
+		for i := range allocCfg.IncludeStates {
+			if strings.ToLower(alloc.ClientStatus) == strings.ToLower(allocCfg.IncludeStates[i]) {
 				return false
 			}
 		}

--- a/pkg/watcher/allocations.go
+++ b/pkg/watcher/allocations.go
@@ -84,7 +84,7 @@ func isFiltered(alloc *api.AllocationListStub, allocCfg *config.AllocConfig) boo
 				return false
 			}
 		}
-		log.Debug().Str("alloc-id", alloc.ID).Str("client-status", alloc.ClientStatus).Msg("allocation client not whitelisted, omitting")
+		log.Debug().Str("alloc-id", alloc.ID).Str("client-status", alloc.ClientStatus).Msg("allocation client status not whitelisted, omitting")
 		return true
 	}
 

--- a/pkg/watcher/allocations.go
+++ b/pkg/watcher/allocations.go
@@ -3,6 +3,8 @@ package watcher
 import (
 	"time"
 
+	"github.com/jrasell/nomad-toast/pkg/config"
+
 	"github.com/hashicorp/nomad/api"
 	"github.com/rs/zerolog/log"
 )
@@ -47,22 +49,44 @@ func (w *Watcher) runAllocationWatcher() {
 		log.Debug().Msg("allocations index has changed")
 
 		for _, alloc := range allocations {
-
+			// If the allocation's index hasn't changed, then there is nothing to notify about
 			if !w.indexHasChange(alloc.ModifyIndex, maxFound) {
 				log.Debug().Str("alloc-id", alloc.ID).Msg("allocation index has not changed")
 				continue
 			}
 
-			if len(alloc.TaskGroup) == 0 {
-				continue
-			}
-
+			// If the allocation index *has* changed, check if the change is of interest
 			maxFound = alloc.ModifyIndex
 			log.Info().Str("alloc-id", alloc.ID).Msg("allocation index has changed")
+			if isFiltered(alloc, w.config.nomad.AllocCfg) {
+				continue
+			}
 
 			w.mshChan <- alloc
 		}
 		q.WaitIndex = maxFound
 		w.lastChangeIndex = maxFound
 	}
+}
+
+// isFiltered checks whether a given update about a notification is to be filtered or not
+func isFiltered(alloc *api.AllocationListStub, allocCfg *config.AllocConfig) bool {
+	for _, cs := range allocCfg.ExcludeStates {
+		if alloc.ClientStatus == cs {
+			log.Debug().Str("alloc-id", alloc.ID).Str("client-status", alloc.ClientStatus).Msg("allocation client status blacklisted, omitting")
+			return true
+		}
+	}
+
+	if allocCfg.IncludeStates != nil {
+		for _, cs := range allocCfg.IncludeStates {
+			if alloc.ClientStatus == cs {
+				return false
+			}
+		}
+		log.Debug().Str("alloc-id", alloc.ID).Str("client-status", alloc.ClientStatus).Msg("allocation client not whitelisted, omitting")
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This PR adds the ability to filter notifications for allocation events by the `ClientStatus` of the allocation.

This is a work in progress, but I'm opening the PR to gather feedback. 

The current implementation is quite rudimentary:

* Simple CLI flag for whitelist/blacklist of states
* no verification if the state provided over the CLI is a valid state

This also hasn't been tested (yet).