### PR TITLE
Add HashiUI link to notification title if enabled.

### DIFF
--- a/cmd/nomad-toast/allocations/command.go
+++ b/cmd/nomad-toast/allocations/command.go
@@ -35,7 +35,7 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		os.Exit(sysexits.Software)
 	}
 
-	n, err := notifier.NewNotifier(cfg.Slack, watcher.Deployments)
+	n, err := notifier.NewNotifier(cfg.Slack, cfg.UI, watcher.Deployments)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to build new allocations notifier")
 		os.Exit(sysexits.Software)

--- a/cmd/nomad-toast/allocations/config.go
+++ b/cmd/nomad-toast/allocations/config.go
@@ -7,9 +7,11 @@ import (
 func getConfig() (*config.ToastConfig, error) {
 	nomadConfig := config.GetNomadConfig()
 	slackConfig := config.GetSlackConfig()
+	uiConfig := config.GetUIConfig()
 
 	return &config.ToastConfig{
 		Nomad: &nomadConfig,
 		Slack: &slackConfig,
+		UI:    &uiConfig,
 	}, nil
 }

--- a/cmd/nomad-toast/deployments/command.go
+++ b/cmd/nomad-toast/deployments/command.go
@@ -35,7 +35,7 @@ func runDeployments(_ *cobra.Command, _ []string) {
 		os.Exit(sysexits.Software)
 	}
 
-	n, err := notifier.NewNotifier(cfg.Slack, watcher.Allocations)
+	n, err := notifier.NewNotifier(cfg.Slack, cfg.UI, watcher.Allocations)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to build new deployments notifier")
 		os.Exit(sysexits.Software)

--- a/cmd/nomad-toast/deployments/config.go
+++ b/cmd/nomad-toast/deployments/config.go
@@ -7,9 +7,11 @@ import (
 func getConfig() (*config.ToastConfig, error) {
 	nomadConfig := config.GetNomadConfig()
 	slackConfig := config.GetSlackConfig()
+	footerConfig := config.GetUIConfig()
 
 	return &config.ToastConfig{
 		Nomad: &nomadConfig,
 		Slack: &slackConfig,
+		UI:    &footerConfig,
 	}, nil
 }

--- a/cmd/nomad-toast/main.go
+++ b/cmd/nomad-toast/main.go
@@ -35,6 +35,7 @@ func main() {
 	config.RegisterLogConfig(rootCmd)
 	config.RegisterNomadConfig(rootCmd)
 	config.RegisterSlackConfig(rootCmd)
+	config.RegisterUIConfig(rootCmd)
 
 	if err := registerCommands(rootCmd); err != nil {
 		fmt.Println("error registering commands:", err)

--- a/pkg/config/toast.go
+++ b/pkg/config/toast.go
@@ -1,7 +1,63 @@
 package config
 
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
 // ToastConfig is the overall config struct used for running nomad-toast.
 type ToastConfig struct {
 	Nomad *NomadConfig
 	Slack *SlackConfig
+	UI    *UI
+}
+
+const (
+	configKeyHashiUIEnabled = "hashiui-enabled"
+	configKeyHashiUIHost    = "hashiui-host"
+)
+
+// UI represents the configuration to provides links to a Nomad UI inside a notification.
+type UI struct {
+	HashiUIEnabled bool
+	HashiUIHost    string
+}
+
+// GetUIConfig uses viper to populate a UI config struct with values.
+func GetUIConfig() UI {
+	return UI{
+		HashiUIEnabled: viper.GetBool(configKeyHashiUIEnabled),
+		HashiUIHost:    viper.GetString(configKeyHashiUIHost),
+	}
+}
+
+// RegisterUIConfig is used by commands to register the UI config flags.
+func RegisterUIConfig(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+
+	{
+		const (
+			key          = configKeyHashiUIEnabled
+			longOpt      = "hashiui-enabled"
+			defaultValue = false
+			description  = "This flag enables adding a link to HashiUI within a notification."
+		)
+
+		flags.Bool(longOpt, defaultValue, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
+			key          = configKeyHashiUIHost
+			longOpt      = "hashiui-host"
+			defaultValue = "http://localhost:8000"
+			description  = "The base URL where the HashiUI lives."
+		)
+
+		flags.String(longOpt, defaultValue, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, defaultValue)
+	}
 }

--- a/pkg/notifier/format.go
+++ b/pkg/notifier/format.go
@@ -30,12 +30,13 @@ func (n *Notifier) formatDeploymentMessage(d *api.Deployment) {
 		})
 	}
 
-	m := &slack.Attachment{
-		Fallback: "",
-		Text:     fmt.Sprintf("Nomad Deployment Notification: %s", strings.ToUpper(n.nomadRegion)),
-		Fields:   f,
-	}
+	m := &slack.Attachment{Fallback: "", Fields: f}
 	m.Fields = f
+	m.Title = fmt.Sprintf("Nomad Deployment Notification: %s", strings.ToUpper(n.nomadRegion))
+
+	if n.config.ui.HashiUIEnabled {
+		m.TitleLink = fmt.Sprintf("%s/nomad/%s/deployments/%s/info", n.config.ui.HashiUIHost, n.nomadRegion, d.ID)
+	}
 
 	switch d.Status {
 	case structs.DeploymentStatusRunning, structs.DeploymentStatusPaused:
@@ -72,12 +73,13 @@ func (n *Notifier) formatAllocationMessage(d *api.AllocationListStub) {
 		})
 	}
 
-	m := &slack.Attachment{
-		Fallback: "",
-		Text:     fmt.Sprintf("Nomad Allocations Notification: %s", strings.ToUpper(n.nomadRegion)),
-		Fields:   f,
-	}
+	m := &slack.Attachment{Fallback: "", Fields: f}
 	m.Fields = f
+	m.Title = fmt.Sprintf("Nomad Allocation Notification: %s", strings.ToUpper(n.nomadRegion))
+
+	if n.config.ui.HashiUIEnabled {
+		m.TitleLink = fmt.Sprintf("%s/nomad/%s/allocations/%s/info", n.config.ui.HashiUIHost, n.nomadRegion, d.ID)
+	}
 
 	switch d.ClientStatus {
 	case structs.AllocClientStatusPending:

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -23,6 +23,7 @@ type Notifier struct {
 
 type notifierConfig struct {
 	slack *config.SlackConfig
+	ui    *config.UI
 }
 
 type notifications struct {
@@ -38,11 +39,11 @@ type notification struct {
 
 // NewNotifier builds a new notifier struct in order to run the nomad-toast notifier task.
 // The message channel is importantly where events are received from the watcher.
-func NewNotifier(cfg *config.SlackConfig, et watcher.EndpointType) (*Notifier, error) {
+func NewNotifier(sCfg *config.SlackConfig, fCfg *config.UI, et watcher.EndpointType) (*Notifier, error) {
 	return &Notifier{
-		config:  &notifierConfig{slack: cfg},
+		config:  &notifierConfig{slack: sCfg, ui: fCfg},
 		MsgChan: make(chan interface{}),
-		slack:   slack.New(cfg.AuthToken),
+		slack:   slack.New(sCfg.AuthToken),
 		state:   &notifications{notifications: make(map[string]notification), nomadType: et},
 	}, nil
 }


### PR DESCRIPTION
This commit add CLI flags which allow notifications to include an
embedded link to HashiUI. The link will direct the user to the
allocation or deployment which provides better and easy feedback
for operators.