### PR TITLE
Build the latest version in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go:
 - "1.11"
 script:
-- make tools
+- make build-tools
 - make
 after_success:
 - if [[ -n "$TRAVIS_TAG" ]]; then make release; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
+FROM golang:1.12.3-alpine3.9 AS builder
+
+WORKDIR /go/src/github.com/jrasell/nomad-toast
+RUN apk add -U make git
+COPY GNUmakefile .
+RUN make build-tools
+COPY . .
+RUN make build
+
 FROM alpine:latest
 
 LABEL maintainer James Rasell<(jamesrasell@gmail.com)> (@jrasell)
 LABEL vendor "jrasell"
 
-ENV NOMAD_TOAST_VERSION v0.0.1-rc1
+COPY --from=builder /go/src/github.com/jrasell/nomad-toast/bin/nomad-toast /usr/local/bin/
+RUN apk add -U ca-certificates
 
-WORKDIR /usr/bin/
-
-RUN buildDeps=' \
-                bash \
-                wget \
-        ' \
-        set -x \
-        && apk --no-cache add $buildDeps ca-certificates \
-        && wget -O nomad-toast https://github.com/jrasell/nomad-toast/releases/download/${NOMAD_TOAST_VERSION}/nomad-toast_linux_amd64 \
-        && chmod +x /usr/bin/nomad-toast \
-        && apk del $buildDeps \
-        && echo "Build complete."
-
-CMD ["nomad-toast", "--help"]
+ENTRYPOINT ["nomad-toast"]
+CMD ["--help"]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,11 @@
 default: check test build
 
-tools: ## Install the tools used to test and build
+build-tools:
 	@echo "==> Installing build tools"
+	go get github.com/ahmetb/govvv
+
+tools: ## Install the tools used to test and build
+	@echo "==> Installing tools"
 	go get github.com/ahmetb/govvv
 	go get github.com/alecthomas/gometalinter
 	go get github.com/goreleaser/goreleaser


### PR DESCRIPTION
👋  This builds the latest version of nomad-toast in the Dockerfile. It splits out the dependencies of the make file into two groups, and takes advantage of docker layer caching to speed up builds.