### PR TITLE
Fix updating of slack messages

### DIFF
--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -15,6 +15,7 @@ type Notifier struct {
 	config *notifierConfig
 	slack  *slack.Client
 	state  *notifications
+	chanID *string
 
 	MsgChan chan interface{}
 

--- a/pkg/notifier/slack.go
+++ b/pkg/notifier/slack.go
@@ -22,6 +22,9 @@ func (n *Notifier) sendNewMsg(nomadID string, msg slack.Attachment) {
 		log.Error().Err(err).Str("channel", chanID).Msg("failed to send new Slack notification")
 		return
 	}
+	if n.chanID == nil {
+		n.chanID = &chanID
+	}
 
 	n.newNotifierState(nomadID, ts, msg)
 
@@ -33,7 +36,7 @@ func (n *Notifier) sendUpdateMsg(id, ts string, msg slack.Attachment) {
 	attachOpts := slack.MsgOptionAttachments(msg)
 	opts := []slack.MsgOption{u, attachOpts}
 
-	chanID, ts, _, err := n.slack.SendMessage(n.config.slack.Channel, opts...)
+	chanID, ts, _, err := n.slack.SendMessage(*n.chanID, opts...)
 	if err != nil {
 		log.Error().Err(err).Str("channel", chanID).Msg("failed to send update Slack notification")
 	}


### PR DESCRIPTION
The underlying library API is pretty confusing, and it appears that
`SendMessage` needs the channel ID, rather than the channel name when
sending an update.

Fixes #17.