### PR TITLE
(#2) Update cfg to ensure version cmd works

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ tools: ## Install the tools used to test and build
 
 build: ## Build nomad-toast for development purposes
 	@echo "==> Running $@..."
-	govvv build -o ./bin/nomad-toast ./cmd/nomad-toast -version local
+	govvv build -o ./bin/nomad-toast ./cmd/nomad-toast -version local -pkg "github.com/jrasell/nomad-toast/pkg/buildconsts"
 
 test: ## Run the nomad-toast test suite with coverage
 	@echo "==> Running $@..."

--- a/cmd/nomad-toast/goreleaser.yml
+++ b/cmd/nomad-toast/goreleaser.yml
@@ -29,7 +29,14 @@ builds:
   # - Version (Tag with the `v` prefix stripped)
   # The default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}`
   # Date format is `2006-01-02_15:04:05`
-  ldflags: -s -w -X main.Version={{.Version}} -X main.GitCommit={{.Commit}} -X main.BuildDate={{.Date}} -X main.GitBranch={{.Tag}} -X main.GitState={{.Tag}} -X main.GitSummary={{.Commit}}
+  ldflags: >-
+    -s -w
+    -X github.com/jrasell/nomad-toast/pkg/buildconsts.Version={{.Version}}
+    -X github.com/jrasell/nomad-toast/pkg/buildconsts.GitCommit={{.Commit}}
+    -X github.com/jrasell/nomad-toast/pkg/buildconsts.BuildDate={{.Date}}
+    -X github.com/jrasell/nomad-toast/pkg/buildconsts.GitBranch={{.Tag}}
+    -X github.com/jrasell/nomad-toast/pkg/buildconsts.GitState={{.Tag}}
+    -X github.com/jrasell/nomad-toast/pkg/buildconsts.GitSummary={{.Commit}}
   main: ./cmd/nomad-toast/
 
 archive:

--- a/pkg/buildconsts/consts.go
+++ b/pkg/buildconsts/consts.go
@@ -3,8 +3,8 @@ package buildconsts
 import "fmt"
 
 var (
-	// Date is the date and time at which the platform was built.
-	Date string
+	// BuildDate is the date and time at which the platform was built.
+	BuildDate string
 
 	// GitCommit is the SHA of the commit from which the platform was built.
 	GitCommit string
@@ -36,5 +36,5 @@ func GetVersion() string {
 	}
 
 	return fmt.Sprintf("%s %s\n Date: %s\n Commit: %s\n Branch: %s\n State: %s\n Summary:%s",
-		ProjectName, Version, Date, gitCommit, GitBranch, GitState, GitSummary)
+		ProjectName, Version, BuildDate, gitCommit, GitBranch, GitState, GitSummary)
 }


### PR DESCRIPTION
This is done by ensuring that the import path passed to the linker is
correct - this is needed because the build constants are not in the
main package, so the default import path of `main.` doesn't work.

I've tested this works locally with `make build` and also tested
goreleaser with
```
goreleaser release --rm-dist --skip-publish --config=./cmd/nomad-toast/goreleaser.yml --skip-validate
```